### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/dev.env.sample
+++ b/dev.env.sample
@@ -1,2 +1,2 @@
-CT_URL=http://mymychine:9000
-LOCAL_URL=http://mymychine:3000
+CT_URL=http://mymachine:9000
+LOCAL_URL=http://mymachine:4500

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -10,6 +10,8 @@ services:
     environment:
       PORT: 4500
       NODE_PATH: app/src
+      CT_URL: http://mymachine:9000
+      LOCAL_URL: http://mymachine:4500
       CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
       API_VERSION: v1
       # NEO4J_URI: bolt://mymachine:7687


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Fix config sample typos
- Add local and CT URL config